### PR TITLE
Requirements setup.py 'google-auth' package not working properly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         'csv342', # Py2/3 compatibility
         ] + ([
         'gspread<4', # Py2 dropped
-        'google-auth<=1.34', # Py2 dropped
+        'google-auth<1.35.0', # Py2 dropped
         'google-auth-oauthlib<0.4.2', # Py2 dropped
         'oauthlib<3', # Py2 dropped
         'requests-oauthlib<1.2', # Py2 dropped


### PR DESCRIPTION
Seams that operator <= or number version not working in setup.py install requires

![image](https://github.com/Som-Energia/somenergia-utils/assets/26488435/49f5223f-d37c-4a81-978d-856fb5309782)
